### PR TITLE
increment version to v0.1.1, add prod pypi publish

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -8,6 +8,11 @@ on:
       - '*'
   pull_request:
   workflow_dispatch:
+    inputs:
+      release:
+        description: "Release wheel to Production PyPI"
+        required: false
+        type: boolean
 
 jobs:
   build:
@@ -96,8 +101,29 @@ jobs:
         with:
           name: wheel
           path: dist/
-      
+
       - name: Publish package distributions to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+
+  publish-to-pypi:
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    if: ${{ startsWith(github.ref, 'refs/tags/') && inputs.release }}
+    environment:
+      name: Production PyPI Publish
+      url: https://pypi.org/project/model-hosting-container-standards/
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wheel
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/python/model_hosting_container_standards/__init__.py
+++ b/python/model_hosting_container_standards/__init__.py
@@ -5,4 +5,4 @@ Framework-specific functionality should be imported from their respective submod
 - FastAPI: from .common.fastapi import EnvVars, ENV_CONFIG
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "model-hosting-container-standards"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python toolkit for standardized model hosting container implementations with Amazon SageMaker integration"
 authors = [
     {name = "Amazon Web Services"}


### PR DESCRIPTION
Increment to v0.1.1 because v0.1.0 was released to test PyPi. Want to keep v0.1.0 tag consistent to what was released, although the diffs would only be in the workflow files. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
