### PR TITLE
chore(sagemaker/sessions): add stateful_session_manager to __all__ in…

### DIFF
--- a/python/model_hosting_container_standards/sagemaker/__init__.py
+++ b/python/model_hosting_container_standards/sagemaker/__init__.py
@@ -149,6 +149,7 @@ __all__: List[str] = [
     "register_ping_handler",
     "register_invocation_handler",
     "inject_adapter_id",
+    "stateful_session_manager",
     "bootstrap",
     "RouteConfig",
 ]


### PR DESCRIPTION
… sagemaker/__init__.py

*Issue #, if available:* N/A

*Description of changes:* Adding `stateful_session_manager` to `__all__` list in sagemaker/__init__.py to match previous conventions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
