### PR TITLE
fix: change pydantic validation httpexception raise detail

### DIFF
--- a/python/model_hosting_container_standards/sagemaker/lora/transforms/register.py
+++ b/python/model_hosting_container_standards/sagemaker/lora/transforms/register.py
@@ -26,7 +26,7 @@ def validate_sagemaker_register_request(
         return sagemaker_request
     except ValidationError as e:
         raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST, detail=e.errors(include_url=False)
+            status_code=HTTPStatus.BAD_REQUEST, detail=e.json(include_url=False)
         )
 
 

--- a/python/model_hosting_container_standards/sagemaker/sessions/transform.py
+++ b/python/model_hosting_container_standards/sagemaker/sessions/transform.py
@@ -34,7 +34,7 @@ def _parse_session_request(request_data: dict) -> Optional[SessionRequest]:
         # If requestType is present but validation failed, it's a malformed session request
         if "requestType" in request_data:
             raise HTTPException(
-                status_code=HTTPStatus.BAD_REQUEST, detail=e.errors(include_url=False)
+                status_code=HTTPStatus.BAD_REQUEST, detail=e.json(include_url=False)
             )
         # Not a session request
         return None


### PR DESCRIPTION
fix: change pydantic validation httpexception raise detail to use e.j…son() instead of e.errors()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
