### PR TITLE
chore: bump version to 0.1.14 and fix black formatting

### DIFF
--- a/python/model_hosting_container_standards/__init__.py
+++ b/python/model_hosting_container_standards/__init__.py
@@ -5,4 +5,4 @@ Framework-specific functionality should be imported from their respective submod
 - FastAPI: from .common.fastapi import EnvVars, ENV_CONFIG
 """
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"

--- a/python/model_hosting_container_standards/logging_config.py
+++ b/python/model_hosting_container_standards/logging_config.py
@@ -27,9 +27,7 @@ def parse_level(level: str) -> Union[int, str]:
 
 def _get_env_log_level() -> Union[int, str]:
     """Get the log level from environment variables, defaulting to ERROR."""
-    level = os.getenv(
-        "SAGEMAKER_CONTAINER_LOG_LEVEL", os.getenv("LOG_LEVEL", "ERROR")
-    )
+    level = os.getenv("SAGEMAKER_CONTAINER_LOG_LEVEL", os.getenv("LOG_LEVEL", "ERROR"))
     return parse_level(level)
 
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "model-hosting-container-standards"
-version = "0.1.13"
+version = "0.1.14"
 description = "Python toolkit for standardized model hosting container implementations with Amazon SageMaker integration"
 authors = ["Amazon Web Services"]
 readme = "README.md"


### PR DESCRIPTION
- Bump version in pyproject.toml and __init__.py to 0.1.14
- Fix black formatting in logging_config.py (single-line os.getenv call)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
