### PR TITLE
feat: automatic requirements.txt installation in standard-supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ ModelHostingContainerStandards/
 │   │   ├── common/            # Common utilities
 │   │   │   ├── fastapi/       # FastAPI integration
 │   │   │   ├── custom_code_ref_resolver/  # Dynamic code loading
+│   │   │   ├── dependency_manager.py  # Pre-launch requirements.txt installation
 │   │   │   └── handler/       # Handler specifications
 │   │   └── sagemaker/         # SageMaker integration
 │   │       ├── lora/          # LoRA adapter support

--- a/docs/sagemaker/06_dependency_installation.md
+++ b/docs/sagemaker/06_dependency_installation.md
@@ -1,0 +1,154 @@
+# Automatic Dependency Installation
+
+Install custom Python dependencies from your model artifacts before the inference server starts.
+
+## Overview
+
+When deploying models on SageMaker, you may need additional Python packages that aren't included in the container image. The `standard-supervisor` CLI automatically installs dependencies from a `requirements.txt` file found in your model artifacts, using `uv` for fast resolution (with `pip` as a fallback).
+
+This runs once at container startup, before the inference server process begins — so all packages are available when your model loads.
+
+## How It Works
+
+```
+Container starts
+  → standard-supervisor parses launch command
+  → Installs dependencies (if requirements.txt found)
+  → Starts the inference server under supervision
+```
+
+The installer resolves the Python interpreter from the launch command (e.g., `python3` in `standard-supervisor python3 -m vllm ...`) to ensure packages are installed into the correct site-packages.
+
+## Quick Start
+
+Place a `requirements.txt` in your model artifact directory:
+
+```
+/opt/ml/model/
+├── requirements.txt      # Your Python dependencies
+├── config.json           # Model config
+├── model.safetensors     # Model weights
+└── tokenizer.json        # Tokenizer
+```
+
+That's it. The `standard-supervisor` discovers and installs it automatically.
+
+### Example requirements.txt
+
+```txt
+transformers>=4.40.0
+scipy==1.13.0
+custom-tokenizer==1.0.0
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STANDARD_AUTO_INSTALL_REQ` | `true` | Set to `false` to disable automatic installation entirely. |
+| `STANDARD_PIP_ARGS` | *(unset)* | When set, replaces auto-discovery. The value is passed directly as arguments to `uv pip install` (or `pip install`). |
+
+### STANDARD_AUTO_INSTALL_REQ
+
+Controls whether the dependency installation step runs at all.
+
+```bash
+# Disable automatic installation
+docker run -e STANDARD_AUTO_INSTALL_REQ=false my-image
+```
+
+### STANDARD_PIP_ARGS
+
+When set, auto-discovery of `/opt/ml/model/requirements.txt` is skipped entirely. The value is used as the full set of arguments to the install command.
+
+```bash
+# Install from a custom file location
+docker run -e STANDARD_PIP_ARGS="-r /custom/path/requirements.txt" my-image
+
+# Install from a custom index
+docker run -e STANDARD_PIP_ARGS="-r /opt/ml/model/requirements.txt --index-url https://my-index/simple" my-image
+
+# Install specific packages directly
+docker run -e STANDARD_PIP_ARGS="scipy==1.13.0 pandas" my-image
+```
+
+## Auto-Discovery Behavior
+
+When `STANDARD_PIP_ARGS` is **not set**, the installer runs in auto-discovery mode:
+
+1. Looks for `requirements.txt` in the model directory (`SAGEMAKER_MODEL_PATH` or `/opt/ml/model`).
+2. If found, runs `uv pip install -r /opt/ml/model/requirements.txt`.
+3. If a `requirements/` subdirectory exists alongside the file, adds `--find-links` for offline installs.
+4. If no `requirements.txt` is found, the step is a silent no-op.
+
+When `STANDARD_PIP_ARGS` **is set**, auto-discovery is skipped entirely to avoid duplicate `-r` flags. The customer's value is the complete set of install arguments.
+
+## Offline / Air-Gapped Installs
+
+For environments without internet access, bundle wheel files in a `requirements/` subdirectory:
+
+```
+/opt/ml/model/
+├── requirements.txt
+└── requirements/
+    ├── scipy-1.13.0-cp312-cp312-linux_x86_64.whl
+    └── custom_tokenizer-1.0.0-py3-none-any.whl
+```
+
+The installer automatically detects this directory and passes `--find-links` to pip, so packages resolve locally without network access.
+
+## Installer Resolution
+
+The installer prefers `uv` for speed, falling back to `pip` if `uv` is not available:
+
+| Priority | Tool | Command |
+|----------|------|---------|
+| 1 | `uv` (on PATH) | `uv pip install --python <python> -r requirements.txt` |
+| 2 | `pip` (in target Python) | `<python> -m pip install -r requirements.txt` |
+
+If `uv` is not on PATH, the installer falls back to `pip`. If `pip` is also missing, the install command fails and the error output from pip is logged.
+
+## Python Interpreter Resolution
+
+The installer determines which Python to target by inspecting the launch command passed to `standard-supervisor`:
+
+| Launch command | Resolved Python |
+|----------------|-----------------|
+| `standard-supervisor python3 -m vllm ...` | `python3` (resolved via PATH) |
+| `standard-supervisor /opt/venv/bin/python3.12 -m vllm ...` | `/opt/venv/bin/python3.12` |
+| `standard-supervisor vllm serve ...` | `sys.executable` (the Python running standard-supervisor) |
+
+This ensures packages are installed into the same site-packages the inference server will use.
+
+## Troubleshooting
+
+### Dependencies not being installed
+
+Check that:
+- `requirements.txt` exists at `/opt/ml/model/requirements.txt`
+- `STANDARD_AUTO_INSTALL_REQ` is not set to `false`
+- The entrypoint uses `standard-supervisor` (e.g., `exec standard-supervisor python3 -m vllm ...`)
+
+Enable debug logging to see the install command:
+```bash
+export LOG_LEVEL=debug
+```
+
+### Installation fails
+
+Check the error output in the container logs. Common causes:
+- The package doesn't exist on PyPI or the configured index
+- Network connectivity issues (consider offline installs)
+- Neither `uv` nor `pip` is available in the container
+
+### Wrong Python — packages not importable at runtime
+
+This happens when `standard-supervisor` installs into a different Python than the inference server uses. Ensure the launch command starts with an explicit Python path:
+
+```bash
+# Good — installer can detect python3
+standard-supervisor python3 -m vllm.entrypoints.openai.api_server ...
+
+# Risky — installer falls back to sys.executable
+standard-supervisor vllm serve ...
+```

--- a/python/README.md
+++ b/python/README.md
@@ -7,6 +7,7 @@ A standardized Python framework for seamless integration between ML frameworks (
 This package simplifies model deployment by providing:
 - **Unified Handler System**: Consistent `/ping` and `/invocations` endpoints across frameworks
 - **Flexible Configuration**: Environment variables, decorators, or custom scripts
+- **Automatic Dependency Installation**: Installs `requirements.txt` from model artifacts before server startup
 - **Framework Agnostic**: Works with vLLM, TensorRT-LLM, and other ML frameworks
 - **Production Ready**: Comprehensive logging, error handling, and debugging tools
 

--- a/python/model_hosting_container_standards/common/dependency_manager.py
+++ b/python/model_hosting_container_standards/common/dependency_manager.py
@@ -1,0 +1,208 @@
+"""Pre-launch dependency installation from customer model artifacts.
+
+Installs Python dependencies from a requirements.txt file found in the model
+directory before the framework server process starts. Designed to be called
+from the standard-supervisor CLI launcher.
+
+Uses ``uv pip install`` when ``uv`` is available on PATH (significantly faster
+dependency resolution), falling back to ``python -m pip install`` otherwise.
+
+Environment Variables:
+    STANDARD_AUTO_INSTALL_REQ: Enable/disable automatic installation (default: true).
+    STANDARD_PIP_ARGS: Explicit install arguments. When set, replaces
+        auto-discovery entirely and runs ``uv pip install <args>`` (or
+        ``pip install <args>``). Use this to point to a custom requirements
+        file (e.g. "-r /path/to/req.txt"), set custom indexes
+        (e.g. "--index-url https://my-index/simple"), or pass any other
+        pip install flags.
+    SAGEMAKER_MODEL_PATH: Model artifact directory (default: /opt/ml/model).
+"""
+
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_PATH = "/opt/ml/model"
+REQUIREMENTS_FILENAME = "requirements.txt"
+
+# Environment variable names
+STANDARD_AUTO_INSTALL_REQ = "STANDARD_AUTO_INSTALL_REQ"
+STANDARD_PIP_ARGS = "STANDARD_PIP_ARGS"
+
+
+def is_auto_install_enabled() -> bool:
+    """Check if automatic dependency installation is enabled."""
+    enabled = os.getenv(STANDARD_AUTO_INSTALL_REQ, "true")
+    return enabled.lower() in ("true", "1", "yes", "on")
+
+
+def resolve_python_from_command(launch_command: List[str]) -> str:
+    """Extract the Python interpreter from a launch command.
+
+    Inspects the launch command to determine which Python interpreter the
+    framework will run under, so that pip installs packages into the correct
+    site-packages.
+
+    Resolution order:
+        1. If the command starts with an explicit Python path or name
+           (e.g. "python3", "/usr/bin/python3.12", "python"),
+           return that value resolved to an absolute path via shutil.which
+           if it is a bare name.
+        2. Otherwise fall back to sys.executable (the Python running
+           standard-supervisor itself).
+
+    Args:
+        launch_command: The launch command as a list of strings, e.g.
+            ["python3", "-m", "vllm.entrypoints.openai.api_server", "--port", "8080"]
+            or ["vllm", "serve", "model"].
+
+    Returns:
+        Absolute path to the Python interpreter to use for pip install.
+    """
+    if not launch_command:
+        return sys.executable
+
+    first = launch_command[0]
+    basename = os.path.basename(first)
+
+    # Match python, python3, python3.12, etc.
+    if basename == "python" or basename.startswith("python3"):
+        resolved = shutil.which(first)
+        if resolved:
+            logger.debug(
+                "Resolved Python from launch command: %s -> %s", first, resolved
+            )
+            return resolved
+        # If which() fails (e.g. absolute path that exists but isn't on PATH)
+        if os.path.isfile(first) and os.access(first, os.X_OK):
+            logger.debug("Using Python from launch command directly: %s", first)
+            return first
+
+    # Not an explicit python invocation (e.g. "vllm serve ...")
+    logger.debug(
+        "No Python interpreter found in launch command, using sys.executable: %s",
+        sys.executable,
+    )
+    return sys.executable
+
+
+def _build_install_prefix(python: str) -> List[str]:
+    """Build the install command prefix, preferring uv over pip.
+
+    Uses ``uv pip install --python <python>`` if ``uv`` is on PATH,
+    otherwise falls back to ``<python> -m pip install``. If pip is also
+    missing, the subsequent subprocess call will fail and
+    ``install_requirements`` handles the error.
+
+    Args:
+        python: Path to the target Python interpreter.
+
+    Returns:
+        Command prefix list.
+    """
+    if shutil.which("uv"):
+        logger.debug("Using uv for dependency installation")
+        return ["uv", "pip", "install", "--python", python]
+
+    logger.debug("uv not found, falling back to pip")
+    return [python, "-m", "pip", "install"]
+
+
+def install_requirements(
+    model_path: Optional[str] = None,
+    requirements_filename: str = REQUIREMENTS_FILENAME,
+    pip_args: Optional[str] = None,
+    python_executable: Optional[str] = None,
+) -> bool:
+    """Install Python dependencies from requirements.txt or explicit args.
+
+    Uses ``uv pip install`` when available, falling back to ``pip install``.
+
+    Two modes of operation:
+
+    1. **Auto-discovery** (default, no STANDARD_PIP_ARGS):
+       Looks for requirements_filename in model_path. If found, runs
+       ``uv pip install -r <file>``. Also checks for a ``requirements/``
+       subdirectory to support offline installs via ``--find-links``.
+
+    2. **Explicit** (STANDARD_PIP_ARGS is set):
+       Runs ``uv pip install <args>`` using exactly the customer-provided
+       arguments. Auto-discovery is skipped entirely to avoid duplicate
+       ``-r`` flags pointing to the same file.
+
+    Args:
+        model_path: Model artifact directory for auto-discovery. Defaults to
+                    SAGEMAKER_MODEL_PATH env var, then /opt/ml/model.
+        requirements_filename: Filename to look for during auto-discovery.
+        pip_args: Explicit pip install arguments. When set, replaces
+                        auto-discovery entirely. Parsed with shlex.split.
+        python_executable: Python interpreter to use for pip. Defaults to
+                           sys.executable.
+
+    Returns:
+        True if installation succeeded or was skipped (no file found).
+        False if installation failed.
+    """
+    python = python_executable or sys.executable
+
+    if pip_args:
+        # Explicit mode: customer owns the install arguments entirely.
+        # No auto-discovery to avoid duplicate -r flags.
+        try:
+            parsed_args = shlex.split(pip_args)
+        except ValueError as e:
+            logger.error("Invalid STANDARD_PIP_ARGS: %s", e)
+            return False
+        install_prefix = _build_install_prefix(python)
+        cmd = install_prefix + parsed_args
+        logger.info("Installing dependencies from explicit pip args...")
+    else:
+        # Auto-discovery mode: look for requirements.txt in model directory.
+        model_dir_path = (
+            model_path or os.environ.get("SAGEMAKER_MODEL_PATH") or DEFAULT_MODEL_PATH
+        )
+        model_dir = Path(model_dir_path)
+        req_file = model_dir / requirements_filename
+
+        if not req_file.is_file():
+            logger.debug("No %s found in %s", requirements_filename, model_dir)
+            return True
+
+        install_prefix = _build_install_prefix(python)
+
+        cmd = install_prefix + ["-r", str(req_file)]
+
+        # Support offline installs via local packages directory
+        local_packages = model_dir / "requirements"
+        if local_packages.is_dir():
+            cmd.extend(["--find-links", str(local_packages)])
+            logger.info("Using local packages directory: %s", local_packages)
+
+        logger.info("Installing dependencies from %s ...", req_file)
+
+    logger.debug("pip command: %s", cmd)
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode == 0:
+            logger.info("Dependency installation completed successfully")
+            if result.stdout:
+                logger.debug("pip output:\n%s", result.stdout)
+            return True
+        else:
+            logger.error(
+                "Dependency installation failed (exit %d):\n%s",
+                result.returncode,
+                result.stderr,
+            )
+            return False
+    except Exception:
+        logger.exception("Unexpected error during dependency installation")
+        return False

--- a/python/model_hosting_container_standards/supervisor/README.md
+++ b/python/model_hosting_container_standards/supervisor/README.md
@@ -135,6 +135,41 @@ docker run \
   my-image
 ```
 
+## Automatic Dependency Installation
+
+`standard-supervisor` automatically installs Python dependencies from a `requirements.txt` file in the model directory before starting the inference server. This uses `uv` when available, falling back to `pip`.
+
+### Default Behavior
+
+If `/opt/ml/model/requirements.txt` exists, it is installed automatically. No configuration needed.
+
+### Configuration
+
+```bash
+# Disable automatic installation
+export STANDARD_AUTO_INSTALL_REQ=false
+
+# Use explicit pip arguments instead of auto-discovery
+export STANDARD_PIP_ARGS="-r /custom/path/requirements.txt --index-url https://my-index/simple"
+```
+
+When `STANDARD_PIP_ARGS` is set, auto-discovery is skipped — the value is passed directly as arguments to the install command.
+
+### Offline Installs
+
+Place wheel files in a `requirements/` subdirectory alongside `requirements.txt`:
+
+```
+/opt/ml/model/
+├── requirements.txt
+└── requirements/
+    └── my_package-1.0.0-py3-none-any.whl
+```
+
+The installer automatically adds `--find-links` to resolve packages locally.
+
+For full details, see [Dependency Installation Guide](../../../docs/sagemaker/06_dependency_installation.md).
+
 ## Complete Examples
 
 ### Basic vLLM Example
@@ -295,5 +330,6 @@ standard-supervisor ./my-custom-entrypoint.sh
 
 - `scripts/standard_supervisor.py` - Main CLI entry point (`standard-supervisor` command)
 - `scripts/generate_supervisor_config.py` - Configuration generator (used internally)
+- `../common/dependency_manager.py` - Pre-launch dependency installation logic
 
 That's all you need! The supervisor system handles the rest automatically.

--- a/python/model_hosting_container_standards/supervisor/scripts/standard_supervisor.py
+++ b/python/model_hosting_container_standards/supervisor/scripts/standard_supervisor.py
@@ -135,6 +135,41 @@ class StandardSupervisor:
 
         return launch_command
 
+    def _install_dependencies(self, launch_command: List[str]) -> bool:
+        """Install customer dependencies if enabled via STANDARD_AUTO_INSTALL_REQ.
+
+        Extracts the Python interpreter from the launch command so that packages
+        are installed into the same site-packages the framework will use.
+
+        Args:
+            launch_command: The framework launch command (e.g.
+                ["python3", "-m", "vllm.entrypoints.openai.api_server", ...]).
+
+        Returns:
+            True if installation succeeded or was skipped.
+            False if installation failed.
+        """
+        from model_hosting_container_standards.common.dependency_manager import (
+            STANDARD_PIP_ARGS,
+            install_requirements,
+            is_auto_install_enabled,
+            resolve_python_from_command,
+        )
+
+        if not is_auto_install_enabled():
+            self.logger.info("Automatic requirements installation disabled")
+            return True
+
+        python_executable = resolve_python_from_command(launch_command)
+        pip_args = os.getenv(STANDARD_PIP_ARGS)
+        success = install_requirements(
+            pip_args=pip_args,
+            python_executable=python_executable,
+        )
+        if not success:
+            self.logger.error("Dependency installation failed, aborting startup")
+        return success
+
     def run(self) -> int:
         """Main execution method."""
         launch_command = self.parse_arguments()
@@ -145,6 +180,10 @@ class StandardSupervisor:
             config = parse_environment_variables()
         except ConfigurationError as e:
             self.logger.error(f"Configuration error: {e}")
+            return 1
+
+        # Pre-launch: install customer dependencies from model artifacts
+        if not self._install_dependencies(launch_command):
             return 1
 
         config_path = config.config_path
@@ -204,6 +243,24 @@ def _launch_command_directly() -> None:
         print("ERROR: No launch command provided", file=sys.stderr)
         print("Usage: standard-supervisor <launch_command> [args...]", file=sys.stderr)
         sys.exit(1)
+
+    # Pre-launch: install customer dependencies from model artifacts
+    from model_hosting_container_standards.common.dependency_manager import (
+        STANDARD_PIP_ARGS,
+        install_requirements,
+        is_auto_install_enabled,
+        resolve_python_from_command,
+    )
+
+    if is_auto_install_enabled():
+        python_executable = resolve_python_from_command(launch_command)
+        pip_args = os.getenv(STANDARD_PIP_ARGS)
+        if not install_requirements(
+            pip_args=pip_args,
+            python_executable=python_executable,
+        ):
+            print("ERROR: Dependency installation failed", file=sys.stderr)
+            sys.exit(1)
 
     # Replace current process with the command
     # If execvp fails, it will raise an exception and Python will exit

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "model-hosting-container-standards"
-version = "0.1.14"
+version = "0.1.15"
 description = "Python toolkit for standardized model hosting container implementations with Amazon SageMaker integration"
 authors = ["Amazon Web Services"]
 readme = "README.md"

--- a/python/tests/common/test_dependency_manager.py
+++ b/python/tests/common/test_dependency_manager.py
@@ -1,0 +1,544 @@
+"""Unit tests for dependency_manager module."""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from model_hosting_container_standards.common.dependency_manager import (
+    REQUIREMENTS_FILENAME,
+    STANDARD_AUTO_INSTALL_REQ,
+    _build_install_prefix,
+    install_requirements,
+    is_auto_install_enabled,
+    resolve_python_from_command,
+)
+
+# Patch target for shutil.which inside dependency_manager module
+_WHICH_PATCH = (
+    "model_hosting_container_standards.common.dependency_manager.shutil.which"
+)
+
+
+def _mock_which_has_uv(cmd):
+    """Mock shutil.which that reports uv as available."""
+    if cmd == "uv":
+        return "/usr/bin/uv"
+    return None
+
+
+class TestInstallRequirements:
+    """Tests for install_requirements function."""
+
+    def test_no_requirements_file_returns_true(self, tmp_path):
+        """No requirements.txt present — should succeed silently."""
+        result = install_requirements(model_path=str(tmp_path))
+        assert result is True
+
+    def test_successful_install_with_uv(self, tmp_path):
+        """requirements.txt exists, uv available — should use uv pip install."""
+        req_file = tmp_path / REQUIREMENTS_FILENAME
+        req_file.write_text("requests==2.31.0\n")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Successfully installed requests-2.31.0"
+
+        with patch(_WHICH_PATCH, side_effect=_mock_which_has_uv):
+            with patch("subprocess.run", return_value=mock_result) as mock_run:
+                result = install_requirements(model_path=str(tmp_path))
+
+        assert result is True
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:3] == ["uv", "pip", "install"]
+        assert "--python" in cmd
+        assert "-r" in cmd
+        assert str(req_file) in cmd
+
+    def test_successful_install_without_uv(self, tmp_path):
+        """requirements.txt exists, uv not available — should fall back to pip."""
+        req_file = tmp_path / REQUIREMENTS_FILENAME
+        req_file.write_text("requests==2.31.0\n")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Successfully installed requests-2.31.0"
+
+        with patch(_WHICH_PATCH, return_value=None):
+            with patch("subprocess.run", return_value=mock_result) as mock_run:
+                result = install_requirements(model_path=str(tmp_path))
+
+        assert result is True
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == sys.executable
+        assert cmd[1:4] == ["-m", "pip", "install"]
+        assert "-r" in cmd
+        assert str(req_file) in cmd
+
+    def test_failed_install_returns_false(self, tmp_path):
+        """pip install fails — should return False."""
+        req_file = tmp_path / REQUIREMENTS_FILENAME
+        req_file.write_text("nonexistent-package-xyz\n")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "ERROR: No matching distribution"
+
+        with patch("subprocess.run", return_value=mock_result):
+            result = install_requirements(model_path=str(tmp_path))
+
+        assert result is False
+
+    def test_unexpected_exception_returns_false(self, tmp_path):
+        """Unexpected error during install — should return False."""
+        req_file = tmp_path / REQUIREMENTS_FILENAME
+        req_file.write_text("some-package\n")
+
+        with patch("subprocess.run", side_effect=OSError("disk full")):
+            result = install_requirements(model_path=str(tmp_path))
+
+        assert result is False
+
+    def test_local_packages_directory_adds_find_links(self, tmp_path):
+        """requirements/ subdirectory present — should add --find-links."""
+        req_file = tmp_path / REQUIREMENTS_FILENAME
+        req_file.write_text("my-package\n")
+        local_dir = tmp_path / "requirements"
+        local_dir.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = install_requirements(model_path=str(tmp_path))
+
+        assert result is True
+        cmd = mock_run.call_args[0][0]
+        assert "--find-links" in cmd
+        find_links_idx = cmd.index("--find-links")
+        assert cmd[find_links_idx + 1] == str(local_dir)
+
+    def test_pip_args_replaces_auto_discovery(self, tmp_path):
+        """STANDARD_PIP_ARGS replaces auto-discovery entirely."""
+        req_file = tmp_path / REQUIREMENTS_FILENAME
+        req_file.write_text("some-package\n")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = install_requirements(
+                model_path=str(tmp_path),
+                pip_args="-r /custom/requirements.txt --no-cache-dir",
+            )
+
+        assert result is True
+        cmd = mock_run.call_args[0][0]
+        # Should NOT contain the auto-discovered file
+        assert str(req_file) not in cmd
+        # Should contain the customer's args
+        assert "-r" in cmd
+        assert "/custom/requirements.txt" in cmd
+        assert "--no-cache-dir" in cmd
+
+    def test_pip_args_skips_find_links(self, tmp_path):
+        """When extra args are set, auto-discovered --find-links is also skipped."""
+        req_file = tmp_path / REQUIREMENTS_FILENAME
+        req_file.write_text("some-package\n")
+        local_dir = tmp_path / "requirements"
+        local_dir.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = install_requirements(
+                model_path=str(tmp_path),
+                pip_args="-r /custom/requirements.txt",
+            )
+
+        assert result is True
+        cmd = mock_run.call_args[0][0]
+        # Should NOT contain auto-discovered --find-links
+        assert "--find-links" not in cmd
+        assert str(local_dir) not in cmd
+
+    def test_pip_args_works_without_requirements_file(self, tmp_path):
+        """Explicit pip args should work even when no requirements.txt exists in model dir."""
+        # No requirements.txt in tmp_path
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+
+        with patch("subprocess.run", return_value=mock_result):
+            result = install_requirements(
+                model_path=str(tmp_path),
+                pip_args="-r /custom/requirements.txt",
+            )
+
+        assert result is True
+
+    def test_malformed_pip_args_returns_false(self, tmp_path):
+        """Malformed quoting in pip_args should return False, not crash."""
+        with patch("subprocess.run") as mock_run:
+            result = install_requirements(
+                model_path=str(tmp_path),
+                pip_args='--index-url "https://unclosed-quote',
+            )
+
+        assert result is False
+        mock_run.assert_not_called()
+
+    def test_pip_args_none_uses_auto_discovery(self, tmp_path):
+        """pip_args=None should use auto-discovery from model dir."""
+        req_file = tmp_path / REQUIREMENTS_FILENAME
+        req_file.write_text("some-package\n")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+
+        with patch(_WHICH_PATCH, return_value=None):
+            with patch("subprocess.run", return_value=mock_result) as mock_run:
+                result = install_requirements(model_path=str(tmp_path), pip_args=None)
+
+        assert result is True
+        cmd = mock_run.call_args[0][0]
+        # pip fallback: [python, -m, pip, install, -r, /path/to/requirements.txt]
+        assert len(cmd) == 6
+        assert str(req_file) in cmd
+
+    def test_uses_sagemaker_model_path_env(self, tmp_path):
+        """Should fall back to SAGEMAKER_MODEL_PATH env var."""
+        req_file = tmp_path / REQUIREMENTS_FILENAME
+        req_file.write_text("some-package\n")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+
+        with patch.dict(os.environ, {"SAGEMAKER_MODEL_PATH": str(tmp_path)}):
+            with patch("subprocess.run", return_value=mock_result) as mock_run:
+                result = install_requirements()
+
+        assert result is True
+        cmd = mock_run.call_args[0][0]
+        assert str(req_file) in cmd
+
+    def test_explicit_model_path_overrides_env(self, tmp_path):
+        """Explicit model_path arg should take precedence over env var."""
+        env_dir = tmp_path / "env_dir"
+        env_dir.mkdir()
+        explicit_dir = tmp_path / "explicit_dir"
+        explicit_dir.mkdir()
+        req_file = explicit_dir / REQUIREMENTS_FILENAME
+        req_file.write_text("some-package\n")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+
+        with patch.dict(os.environ, {"SAGEMAKER_MODEL_PATH": str(env_dir)}):
+            with patch("subprocess.run", return_value=mock_result) as mock_run:
+                result = install_requirements(model_path=str(explicit_dir))
+
+        assert result is True
+        cmd = mock_run.call_args[0][0]
+        assert str(req_file) in cmd
+
+    def test_python_executable_used_with_uv(self, tmp_path):
+        """Explicit python_executable should be passed via --python when uv is available."""
+        req_file = tmp_path / REQUIREMENTS_FILENAME
+        req_file.write_text("some-package\n")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+
+        custom_python = "/opt/venv/bin/python3.12"
+
+        with patch(_WHICH_PATCH, side_effect=_mock_which_has_uv):
+            with patch("subprocess.run", return_value=mock_result) as mock_run:
+                result = install_requirements(
+                    model_path=str(tmp_path),
+                    python_executable=custom_python,
+                )
+
+        assert result is True
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:3] == ["uv", "pip", "install"]
+        python_idx = cmd.index("--python")
+        assert cmd[python_idx + 1] == custom_python
+
+    def test_python_executable_used_without_uv(self, tmp_path):
+        """Explicit python_executable should be cmd[0] when uv is not available."""
+        req_file = tmp_path / REQUIREMENTS_FILENAME
+        req_file.write_text("some-package\n")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+
+        custom_python = "/opt/venv/bin/python3.12"
+
+        with patch(_WHICH_PATCH, return_value=None):
+            with patch("subprocess.run", return_value=mock_result) as mock_run:
+                result = install_requirements(
+                    model_path=str(tmp_path),
+                    python_executable=custom_python,
+                )
+
+        assert result is True
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == custom_python
+        assert cmd[1:4] == ["-m", "pip", "install"]
+
+    def test_python_executable_none_falls_back_to_sys(self, tmp_path):
+        """python_executable=None should use sys.executable."""
+        req_file = tmp_path / REQUIREMENTS_FILENAME
+        req_file.write_text("some-package\n")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+
+        with patch(_WHICH_PATCH, return_value=None):
+            with patch("subprocess.run", return_value=mock_result) as mock_run:
+                result = install_requirements(
+                    model_path=str(tmp_path),
+                    python_executable=None,
+                )
+
+        assert result is True
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == sys.executable
+
+
+class TestBuildInstallPrefix:
+    """Tests for _build_install_prefix function."""
+
+    def test_uses_uv_when_available(self):
+        """Should use uv pip install --python when uv is on PATH."""
+        with patch(_WHICH_PATCH, side_effect=_mock_which_has_uv):
+            prefix = _build_install_prefix("/usr/bin/python3")
+        assert prefix == ["uv", "pip", "install", "--python", "/usr/bin/python3"]
+
+    def test_falls_back_to_pip_when_no_uv(self):
+        """Should use python -m pip install when uv is not on PATH."""
+        with patch(_WHICH_PATCH, return_value=None):
+            prefix = _build_install_prefix("/usr/bin/python3")
+        assert prefix == ["/usr/bin/python3", "-m", "pip", "install"]
+
+
+class TestIsAutoInstallEnabled:
+    """Tests for is_auto_install_enabled function."""
+
+    def test_enabled_by_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(STANDARD_AUTO_INSTALL_REQ, None)
+            assert is_auto_install_enabled() is True
+
+    @pytest.mark.parametrize("value", ["true", "True", "TRUE", "1", "yes", "on"])
+    def test_enabled_truthy_values(self, value):
+        with patch.dict(os.environ, {STANDARD_AUTO_INSTALL_REQ: value}):
+            assert is_auto_install_enabled() is True
+
+    @pytest.mark.parametrize("value", ["false", "False", "FALSE", "0", "no", "off"])
+    def test_disabled_falsy_values(self, value):
+        with patch.dict(os.environ, {STANDARD_AUTO_INSTALL_REQ: value}):
+            assert is_auto_install_enabled() is False
+
+
+class TestInstallRequirementsNoInstaller:
+    """Tests for install_requirements when no installer is available."""
+
+    def test_returns_false_when_pip_missing(self, tmp_path):
+        """Should return False when pip is not available and install fails."""
+        req_file = tmp_path / REQUIREMENTS_FILENAME
+        req_file.write_text("some-package\n")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "No module named pip"
+
+        with patch(_WHICH_PATCH, return_value=None):
+            with patch("subprocess.run", return_value=mock_result):
+                result = install_requirements(model_path=str(tmp_path))
+
+        assert result is False
+
+    def test_no_installer_check_skipped_when_no_requirements(self, tmp_path):
+        """Should not probe for installer when no requirements.txt exists."""
+        with patch(
+            "model_hosting_container_standards.common.dependency_manager._build_install_prefix"
+        ) as mock_prefix:
+            result = install_requirements(model_path=str(tmp_path))
+
+        assert result is True
+        mock_prefix.assert_not_called()
+
+
+class TestResolvePythonFromCommand:
+    """Tests for resolve_python_from_command function."""
+
+    def test_explicit_python3(self):
+        """'python3 -m vllm ...' should resolve python3."""
+        with patch(_WHICH_PATCH, return_value="/usr/bin/python3"):
+            result = resolve_python_from_command(
+                [
+                    "python3",
+                    "-m",
+                    "vllm.entrypoints.openai.api_server",
+                    "--port",
+                    "8080",
+                ]
+            )
+        assert result == "/usr/bin/python3"
+
+    def test_explicit_python(self):
+        """'python -m module' should resolve python."""
+        with patch(_WHICH_PATCH, return_value="/usr/bin/python"):
+            result = resolve_python_from_command(["python", "-m", "some_module"])
+        assert result == "/usr/bin/python"
+
+    def test_versioned_python(self):
+        """'python3.12 -m module' should resolve python3.12."""
+        with patch(_WHICH_PATCH, return_value="/usr/bin/python3.12"):
+            result = resolve_python_from_command(["python3.12", "-m", "some_module"])
+        assert result == "/usr/bin/python3.12"
+
+    def test_absolute_python_path(self):
+        """'/opt/venv/bin/python3 -m module' should use the absolute path."""
+        abs_path = "/opt/venv/bin/python3"
+        with patch(_WHICH_PATCH, return_value=abs_path):
+            result = resolve_python_from_command([abs_path, "-m", "some_module"])
+        assert result == abs_path
+
+    def test_absolute_path_not_on_path_but_exists(self, tmp_path):
+        """Absolute python path that exists but isn't found by which()."""
+        fake_python = tmp_path / "python3"
+        fake_python.write_text("#!/bin/sh\n")
+        fake_python.chmod(0o755)
+
+        with patch(_WHICH_PATCH, return_value=None):
+            result = resolve_python_from_command([str(fake_python), "-m", "module"])
+        assert result == str(fake_python)
+
+    def test_non_python_command_falls_back(self):
+        """'vllm serve model' should fall back to sys.executable."""
+        result = resolve_python_from_command(["vllm", "serve", "model"])
+        assert result == sys.executable
+
+    def test_empty_command_falls_back(self):
+        """Empty launch command should fall back to sys.executable."""
+        result = resolve_python_from_command([])
+        assert result == sys.executable
+
+    def test_which_fails_and_not_a_file(self):
+        """python3 not found by which() and not a file — falls back to sys.executable."""
+        with patch(_WHICH_PATCH, return_value=None):
+            result = resolve_python_from_command(["python3", "-m", "module"])
+        # python3 is not an absolute path to a file, so falls back
+        assert result == sys.executable
+
+
+class TestSupervisorIntegration:
+    """Tests for standard_supervisor.py integration with dependency_manager."""
+
+    def test_install_dependencies_called_with_launch_command(self):
+        """_install_dependencies should pass launch_command to resolve_python_from_command."""
+        from model_hosting_container_standards.supervisor.scripts.standard_supervisor import (
+            StandardSupervisor,
+        )
+
+        supervisor = StandardSupervisor()
+        launch_cmd = ["python3", "-m", "vllm.entrypoints.openai.api_server"]
+
+        with patch(
+            "model_hosting_container_standards.common.dependency_manager.is_auto_install_enabled",
+            return_value=True,
+        ):
+            with patch(
+                "model_hosting_container_standards.common.dependency_manager.resolve_python_from_command",
+                return_value="/usr/bin/python3",
+            ) as mock_resolve:
+                with patch(
+                    "model_hosting_container_standards.common.dependency_manager.install_requirements",
+                    return_value=True,
+                ):
+                    result = supervisor._install_dependencies(launch_cmd)
+
+        assert result is True
+        mock_resolve.assert_called_once_with(launch_cmd)
+
+    def test_install_dependencies_aborts_on_failure(self):
+        """_install_dependencies should return False when install fails."""
+        from model_hosting_container_standards.supervisor.scripts.standard_supervisor import (
+            StandardSupervisor,
+        )
+
+        supervisor = StandardSupervisor()
+
+        with patch(
+            "model_hosting_container_standards.common.dependency_manager.is_auto_install_enabled",
+            return_value=True,
+        ):
+            with patch(
+                "model_hosting_container_standards.common.dependency_manager.resolve_python_from_command",
+                return_value="/usr/bin/python3",
+            ):
+                with patch(
+                    "model_hosting_container_standards.common.dependency_manager.install_requirements",
+                    return_value=False,
+                ):
+                    result = supervisor._install_dependencies(["python3", "-m", "vllm"])
+
+        assert result is False
+
+    def test_install_dependencies_skipped_when_disabled(self):
+        """_install_dependencies should skip when STANDARD_AUTO_INSTALL_REQ=false."""
+        from model_hosting_container_standards.supervisor.scripts.standard_supervisor import (
+            StandardSupervisor,
+        )
+
+        supervisor = StandardSupervisor()
+
+        with patch(
+            "model_hosting_container_standards.common.dependency_manager.is_auto_install_enabled",
+            return_value=False,
+        ):
+            with patch(
+                "model_hosting_container_standards.common.dependency_manager.install_requirements",
+            ) as mock_install:
+                result = supervisor._install_dependencies(["python3", "-m", "vllm"])
+
+        assert result is True
+        mock_install.assert_not_called()
+
+    def test_run_aborts_when_install_fails(self):
+        """StandardSupervisor.run() should return 1 when dependency install fails."""
+        from model_hosting_container_standards.supervisor.scripts.standard_supervisor import (
+            StandardSupervisor,
+        )
+
+        supervisor = StandardSupervisor()
+
+        with patch.object(
+            sys, "argv", ["standard-supervisor", "python3", "-m", "vllm"]
+        ):
+            with patch(
+                "model_hosting_container_standards.supervisor.scripts.standard_supervisor.parse_environment_variables",
+            ):
+                with patch.object(
+                    supervisor, "_install_dependencies", return_value=False
+                ):
+                    result = supervisor.run()
+
+        assert result == 1

--- a/python/tests/integration/test_dependency_install_integration.py
+++ b/python/tests/integration/test_dependency_install_integration.py
@@ -1,0 +1,281 @@
+"""
+Integration tests for automatic dependency installation in standard-supervisor.
+
+Tests verify real end-to-end behavior using isolated virtual environments
+to avoid polluting the host Python and to prevent false positives from
+pre-existing packages.
+
+Tests cover:
+1. Auto-discovery of requirements.txt and actual install
+2. STANDARD_PIP_ARGS explicit mode
+3. STANDARD_AUTO_INSTALL_REQ=false disables installation
+4. Bad package blocks startup with non-zero exit
+5. Malformed STANDARD_PIP_ARGS returns error
+6. Python interpreter resolution from launch command
+"""
+
+import os
+import subprocess
+import textwrap
+import venv
+from pathlib import Path
+
+
+def get_python_cwd():
+    """Get the correct working directory for python module execution."""
+    return str(Path(__file__).parent.parent.parent.absolute())
+
+
+def create_test_venv(venv_dir):
+    """Create a venv with model-hosting-container-standards installed.
+
+    Returns the path to the venv's python executable.
+    """
+    venv.create(venv_dir, with_pip=True, clear=True)
+    venv_python = str(venv_dir / "bin" / "python")
+
+    # Install the local package into the venv
+    subprocess.run(
+        [venv_python, "-m", "pip", "install", "-q", "-e", "."],
+        cwd=get_python_cwd(),
+        check=True,
+        capture_output=True,
+    )
+    return venv_python
+
+
+def run_supervisor(venv_python, launch_cmd, env_overrides=None, timeout=120):
+    """Run standard-supervisor from a venv as a subprocess.
+
+    Uses PROCESS_AUTO_RECOVERY=false so standard-supervisor does execvp
+    (direct launch, no supervisord), keeping the test simple and fast.
+    """
+    env = {
+        **os.environ,
+        "PROCESS_AUTO_RECOVERY": "false",
+        "LOG_LEVEL": "debug",
+    }
+    if env_overrides:
+        env.update(env_overrides)
+
+    cmd = [
+        venv_python,
+        "-m",
+        "model_hosting_container_standards.supervisor.scripts.standard_supervisor",
+    ] + launch_cmd
+
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=get_python_cwd(),
+        env=env,
+    )
+
+
+class TestAutoDiscovery:
+    """Tests for auto-discovery of requirements.txt."""
+
+    def test_installs_from_requirements_txt(self, tmp_path):
+        """A real requirements.txt should be installed and the package importable."""
+        venv_python = create_test_venv(tmp_path / "venv")
+
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "requirements.txt").write_text("six==1.17.0\n")
+
+        # Verify six is NOT already importable in the venv
+        pre_check = subprocess.run(
+            [venv_python, "-c", "import six"],
+            capture_output=True,
+        )
+        assert pre_check.returncode != 0, "six should not be pre-installed in venv"
+
+        script = textwrap.dedent(
+            """\
+            import six
+            print(f"six version: {six.__version__}", flush=True)
+        """
+        )
+        script_file = tmp_path / "verify.py"
+        script_file.write_text(script)
+
+        result = run_supervisor(
+            venv_python,
+            [venv_python, str(script_file)],
+            env_overrides={"SAGEMAKER_MODEL_PATH": str(model_dir)},
+        )
+
+        assert (
+            result.returncode == 0
+        ), f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        assert "six version: 1.17.0" in result.stdout
+
+    def test_no_requirements_file_is_noop(self, tmp_path):
+        """No requirements.txt — should proceed without error."""
+        venv_python = create_test_venv(tmp_path / "venv")
+
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+
+        script_file = tmp_path / "verify.py"
+        script_file.write_text('print("started ok", flush=True)\n')
+
+        result = run_supervisor(
+            venv_python,
+            [venv_python, str(script_file)],
+            env_overrides={"SAGEMAKER_MODEL_PATH": str(model_dir)},
+        )
+
+        assert result.returncode == 0
+        assert "started ok" in result.stdout
+
+    def test_bad_package_fails_startup(self, tmp_path):
+        """A requirements.txt with a nonexistent package should fail with non-zero exit."""
+        venv_python = create_test_venv(tmp_path / "venv")
+
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "requirements.txt").write_text(
+            "this-package-does-not-exist-xyz-12345\n"
+        )
+
+        script_file = tmp_path / "should_not_run.py"
+        script_file.write_text("print('should not reach here')\n")
+
+        result = run_supervisor(
+            venv_python,
+            [venv_python, str(script_file)],
+            env_overrides={"SAGEMAKER_MODEL_PATH": str(model_dir)},
+        )
+
+        assert result.returncode != 0
+        assert "should not reach here" not in result.stdout
+
+
+class TestDisableInstallation:
+    """Tests for STANDARD_AUTO_INSTALL_REQ=false."""
+
+    def test_disabled_skips_install(self, tmp_path):
+        """With auto-install disabled, a bad requirements.txt should not block startup."""
+        venv_python = create_test_venv(tmp_path / "venv")
+
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "requirements.txt").write_text(
+            "this-package-does-not-exist-xyz-12345\n"
+        )
+
+        script_file = tmp_path / "verify.py"
+        script_file.write_text('print("started ok", flush=True)\n')
+
+        result = run_supervisor(
+            venv_python,
+            [venv_python, str(script_file)],
+            env_overrides={
+                "SAGEMAKER_MODEL_PATH": str(model_dir),
+                "STANDARD_AUTO_INSTALL_REQ": "false",
+            },
+        )
+
+        assert result.returncode == 0
+        assert "started ok" in result.stdout
+
+
+class TestExplicitPipArgs:
+    """Tests for STANDARD_PIP_ARGS explicit mode."""
+
+    def test_explicit_args_used_instead_of_auto_discovery(self, tmp_path):
+        """STANDARD_PIP_ARGS should be used instead of auto-discovered file."""
+        venv_python = create_test_venv(tmp_path / "venv")
+
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        # Bad requirements.txt in model dir — should be ignored
+        (model_dir / "requirements.txt").write_text(
+            "this-package-does-not-exist-xyz-12345\n"
+        )
+
+        # Good requirements file elsewhere
+        good_req = tmp_path / "custom_req.txt"
+        good_req.write_text("six==1.17.0\n")
+
+        script = textwrap.dedent(
+            """\
+            import six
+            print(f"six version: {six.__version__}", flush=True)
+        """
+        )
+        script_file = tmp_path / "verify.py"
+        script_file.write_text(script)
+
+        result = run_supervisor(
+            venv_python,
+            [venv_python, str(script_file)],
+            env_overrides={
+                "SAGEMAKER_MODEL_PATH": str(model_dir),
+                "STANDARD_PIP_ARGS": f"-r {good_req}",
+            },
+        )
+
+        assert (
+            result.returncode == 0
+        ), f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        assert "six version: 1.17.0" in result.stdout
+
+    def test_malformed_pip_args_fails(self, tmp_path):
+        """Malformed quoting in STANDARD_PIP_ARGS should fail, not crash."""
+        venv_python = create_test_venv(tmp_path / "venv")
+
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+
+        script_file = tmp_path / "should_not_run.py"
+        script_file.write_text("print('should not reach here')\n")
+
+        result = run_supervisor(
+            venv_python,
+            [venv_python, str(script_file)],
+            env_overrides={
+                "SAGEMAKER_MODEL_PATH": str(model_dir),
+                "STANDARD_PIP_ARGS": '--index-url "https://unclosed-quote',
+            },
+        )
+
+        assert result.returncode != 0
+        assert "should not reach here" not in result.stdout
+
+
+class TestPythonResolution:
+    """Tests for Python interpreter resolution from launch command."""
+
+    def test_resolves_python_from_launch_command(self, tmp_path):
+        """The installer should use the same Python as the launch command."""
+        venv_python = create_test_venv(tmp_path / "venv")
+
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "requirements.txt").write_text("six==1.17.0\n")
+
+        script = textwrap.dedent(
+            """\
+            import sys
+            print(f"python: {sys.executable}", flush=True)
+            import six
+            print(f"six: {six.__version__}", flush=True)
+        """
+        )
+        script_file = tmp_path / "verify.py"
+        script_file.write_text(script)
+
+        result = run_supervisor(
+            venv_python,
+            [venv_python, str(script_file)],
+            env_overrides={"SAGEMAKER_MODEL_PATH": str(model_dir)},
+        )
+
+        assert (
+            result.returncode == 0
+        ), f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        assert "six: 1.17.0" in result.stdout


### PR DESCRIPTION
Add pre-launch dependency installation to the standard-supervisor CLI. When a requirements.txt file is found in the model directory (/opt/ml/model), dependencies are installed automatically before the inference server starts.

Uses uv for fast resolution when available, falling back to pip.

New environment variables:
- STANDARD_AUTO_INSTALL_REQ: enable/disable (default: true)
- STANDARD_PIP_ARGS: explicit pip args, replaces auto-discovery when set

Key behaviors:
- Python interpreter resolved from launch command for correct site-packages
- Offline installs supported via requirements/ subdirectory (--find-links)
- Auto-discovery skipped entirely when STANDARD_PIP_ARGS is set
- Installation failure blocks server startup (hard fail)

Version bumped to 0.1.15.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
