### PR TITLE
fix: use shlex.join to preserve quoting in supervisord command

### DIFF
--- a/python/model_hosting_container_standards/supervisor/scripts/generate_supervisor_config.py
+++ b/python/model_hosting_container_standards/supervisor/scripts/generate_supervisor_config.py
@@ -7,6 +7,7 @@ Simple script to generate supervisord configuration files for ML frameworks.
 
 import argparse
 import logging
+import shlex
 import sys
 
 from model_hosting_container_standards.logging_config import get_logger
@@ -51,8 +52,10 @@ def main() -> int:
         # Parse configuration from environment
         config = parse_environment_variables()
 
-        # Get launch command from CLI arguments
-        launch_command = " ".join(args.command)
+        # Get launch command from CLI arguments. Use shlex.join (inverse of
+        # supervisord's shlex.split on command=) so arguments containing spaces or
+        # quotes — e.g. a JSON value for vLLM's --speculative-config — survive intact.
+        launch_command = shlex.join(args.command)
 
         # Generate and write configuration
         write_supervisord_config(args.output, config, launch_command, args.program_name)

--- a/python/model_hosting_container_standards/supervisor/scripts/standard_supervisor.py
+++ b/python/model_hosting_container_standards/supervisor/scripts/standard_supervisor.py
@@ -14,6 +14,7 @@ Example:
 
 import logging
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -192,10 +193,13 @@ class StandardSupervisor:
         try:
             # Generate and start supervisor
             self.logger.info("Generating supervisor configuration...")
+            # Use shlex.join (inverse of supervisord's shlex.split on command=) so
+            # that arguments containing spaces or quotes — e.g. a JSON value passed
+            # to vLLM's --speculative-config — survive the round-trip intact.
             write_supervisord_config(
                 config_path=config_path,
                 config=config,
-                launch_command=" ".join(launch_command),
+                launch_command=shlex.join(launch_command),
                 program_name=program_name,
             )
 

--- a/python/tests/supervisor/test_generate_supervisor_config.py
+++ b/python/tests/supervisor/test_generate_supervisor_config.py
@@ -1,0 +1,140 @@
+"""
+Unit tests for the generate-supervisor-config CLI.
+
+These tests exercise the script end to end: they invoke ``main()``, read the
+emitted supervisord config file, and assert that the ``command=`` value
+round-trips back to the original argv when parsed with ``shlex.split`` (the
+same parsing supervisord performs). This guards the quote-preservation fix for
+ticket P446501135, where a plain ``" ".join`` corrupted arguments containing
+spaces or quotes (e.g. the JSON passed to vLLM's ``--speculative-config``).
+"""
+
+import configparser
+import os
+import shlex  # inverse of shlex.join; supervisord parses command= the same way
+import sys
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from model_hosting_container_standards.supervisor.scripts.generate_supervisor_config import (  # noqa: E501
+    main,
+)
+
+# Each case is a launch argv that must survive the round-trip intact. They cover
+# JSON values, embedded spaces, single quotes, double quotes, and empty strings.
+ROUND_TRIP_CASES = {
+    "json_speculative_config": [
+        "python3",
+        "-m",
+        "vllm.entrypoints.openai.api_server",
+        "--speculative-config",
+        (
+            '{"model": "/opt/ml/additional-model-data-sources/eagle", '
+            '"method": "eagle3", "num_speculative_tokens": 3, '
+            '"parallel_drafting": true}'
+        ),
+    ],
+    "args_with_spaces": [
+        "vllm",
+        "serve",
+        "my model",
+        "--served-model-name",
+        "my model name",
+    ],
+    "single_quotes": ["echo", "it's a 'quoted' value"],
+    "empty_string_arg": ["python3", "-c", "print('hi')", "--flag", ""],
+    "json_and_plain_mix": [
+        "vllm",
+        "serve",
+        "model",
+        "--chat-template",
+        '{"x": "a b c"}',
+        "--arg",
+        "plain",
+    ],
+}
+
+
+@pytest.fixture
+def clean_env():
+    """Provide a clean supervisor-related environment for each test."""
+    original_env = dict(os.environ)
+    for key in list(os.environ.keys()):
+        if key.startswith("SUPERVISOR_") or key in (
+            "PROCESS_AUTO_RECOVERY",
+            "PROCESS_MAX_START_RETRIES",
+            "LOG_LEVEL",
+        ):
+            del os.environ[key]
+    yield
+    os.environ.clear()
+    os.environ.update(original_env)
+
+
+def _read_command(config_path: str) -> str:
+    """Read the program command from an emitted supervisord config file."""
+    # interpolation=None so '%' inside argument values is not treated as a token.
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.read(config_path)
+    return parser["program:app"]["command"]
+
+
+class TestGenerateSupervisorConfigQuoting:
+    """End-to-end quote-preservation tests for the CLI."""
+
+    @pytest.mark.parametrize(
+        "argv", ROUND_TRIP_CASES.values(), ids=ROUND_TRIP_CASES.keys()
+    )
+    def test_command_round_trips_through_shlex(self, clean_env, argv):
+        """The emitted command= must shlex.split back to the original argv."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = os.path.join(temp_dir, "supervisord.conf")
+
+            # "--" stops argparse option parsing so command args may begin with "-".
+            with patch.object(
+                sys,
+                "argv",
+                ["generate-supervisor-config", "-o", config_path, "--", *argv],
+            ):
+                result = main()
+
+            assert result == 0
+            command = _read_command(config_path)
+            assert shlex.split(command) == argv
+
+    def test_speculative_config_json_stays_single_token(self, clean_env):
+        """Regression for P446501135: the JSON value stays one intact token."""
+        speculative_config = (
+            '{"model": "/opt/ml/additional-model-data-sources/eagle", '
+            '"method": "eagle3", "num_speculative_tokens": 3, '
+            '"parallel_drafting": true}'
+        )
+        argv = [
+            "python3",
+            "-m",
+            "vllm.entrypoints.openai.api_server",
+            "--speculative-config",
+            speculative_config,
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = os.path.join(temp_dir, "supervisord.conf")
+            with patch.object(
+                sys,
+                "argv",
+                ["generate-supervisor-config", "-o", config_path, "--", *argv],
+            ):
+                assert main() == 0
+
+            command = _read_command(config_path)
+            tokens = shlex.split(command)
+
+        assert speculative_config in tokens
+        # The value following --speculative-config must be the full JSON, unsplit.
+        assert tokens[tokens.index("--speculative-config") + 1] == speculative_config
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/tests/supervisor/test_standard_supervisor.py
+++ b/python/tests/supervisor/test_standard_supervisor.py
@@ -6,6 +6,7 @@ without requiring actual supervisor processes or system integration.
 """
 
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -251,6 +252,62 @@ class TestStandardSupervisor:
             result = supervisor.run()
 
         assert result == 1
+
+    @patch(
+        "model_hosting_container_standards.supervisor.scripts.standard_supervisor.parse_environment_variables"
+    )
+    @patch(
+        "model_hosting_container_standards.supervisor.scripts.standard_supervisor.write_supervisord_config"
+    )
+    def test_run_preserves_quoted_json_argument(
+        self, mock_write_config, mock_parse_env
+    ):
+        """Regression test for SM_VLLM_SPECULATIVE_CONFIG quote stripping.
+
+        An argv element that contains spaces and double quotes (such as the JSON
+        passed to vLLM's --speculative-config) must be shell-quoted when joined
+        into supervisord's ``command=`` field. supervisord re-parses that field
+        with ``shlex.split``; with a plain ``" ".join`` the quotes were stripped
+        and the JSON broke apart into multiple tokens. See ticket P446501135.
+        """
+        mock_config = Mock()
+        mock_config.config_path = "/tmp/test.conf"
+        mock_parse_env.return_value = mock_config
+
+        mock_process = Mock()
+        mock_process.poll.side_effect = [None, 0]
+        mock_process.returncode = 0
+
+        supervisor = StandardSupervisor()
+        supervisor.process_manager.start = Mock(return_value=mock_process)
+        supervisor.signal_handler.setup = Mock()
+
+        speculative_config = (
+            '{"model": "/opt/ml/additional-model-data-sources/eagle", '
+            '"method": "eagle3", "num_speculative_tokens": 3, '
+            '"parallel_drafting": true}'
+        )
+        argv = [
+            "python3",
+            "-m",
+            "vllm.entrypoints.openai.api_server",
+            "--speculative-config",
+            speculative_config,
+            "--host",
+            "0.0.0.0",
+        ]
+
+        with patch.object(sys, "argv", ["standard-supervisor", *argv]):
+            with patch("time.sleep"):
+                supervisor.run()
+
+        # The launch_command written to the config must round-trip back to the
+        # original argv when supervisord parses it with shlex.split.
+        _, kwargs = mock_write_config.call_args
+        launch_command = kwargs["launch_command"]
+        assert shlex.split(launch_command) == argv
+        # The JSON value must remain a single intact token.
+        assert speculative_config in shlex.split(launch_command)
 
 
 class TestHelperFunctions:


### PR DESCRIPTION
## Summary

`standard-supervisor` (and `generate-supervisor-config`) collapsed the launch command argv into supervisord's `command=` field with a plain `" ".join(...)`. supervisord re-parses that field with `shlex.split`, which strips double quotes and splits on whitespace. A single argv element that contains spaces and quotes — most importantly the JSON passed to vLLM's `--speculative-config` via `SM_VLLM_SPECULATIVE_CONFIG` — was therefore shredded into multiple broken tokens, so vLLM failed JSON parsing at startup on DLC versions ≥ 0.21.0.

Before (what supervisord received after re-parsing):
```
--speculative-config {model: /opt/ml/additional-model-data-sources/eagle, method: eagle3, ...}
```
After:
```
--speculative-config {"model": "/opt/ml/additional-model-data-sources/eagle", "method": "eagle3", ...}
```

## Fix

Use `shlex.join` — the documented inverse of supervisord's `shlex.split` — so each argument is shell-quoted and the original argv is reconstructed exactly. Applied in both entry points that shared the defect:

- `supervisor/scripts/standard_supervisor.py`
- `supervisor/scripts/generate_supervisor_config.py`

## Tests

Added `test_run_preserves_quoted_json_argument`, which reproduces the exact `SM_VLLM_SPECULATIVE_CONFIG` JSON from the report and asserts the written `command=` round-trips back to the original argv via `shlex.split`. Verified it **fails on the previous `" ".join` code** and **passes with `shlex.join`**. Full unit suite: 613 passed, 52 skipped (async tests; unrelated). Integration tests that spawn a real `supervisord` were not run locally (binary not installed in the dev sandbox) — CI will exercise them.

## Context

Root-caused in SIM-T ticket P446501135 (vLLM DLC ≥0.21 breaks `SM_VLLM_SPECULATIVE_CONFIG`). This is the permanent upstream fix; it also makes the customer's single-quote-wrapping workaround unnecessary.