### PR TITLE
chore: bump version to 0.1.17 for next development cycle

### DIFF
--- a/python/model_hosting_container_standards/__init__.py
+++ b/python/model_hosting_container_standards/__init__.py
@@ -5,4 +5,4 @@ Framework-specific functionality should be imported from their respective submod
 - FastAPI: from .common.fastapi import EnvVars, ENV_CONFIG
 """
 
-__version__ = "0.1.16"
+__version__ = "0.1.17"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "model-hosting-container-standards"
-version = "0.1.16"
+version = "0.1.17"
 description = "Python toolkit for standardized model hosting container implementations with Amazon SageMaker integration"
 authors = ["Amazon Web Services"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Bumps the in-development version to `0.1.17` to open the next development cycle, following the established release cadence (`bump for release` → tag → `bump for next development cycle`).

`0.1.16` was just tagged (`v0.1.16`) and published to TestPyPI — it carries the `shlex.join` supervisord quoting fix (#60, ticket P446501135). This bump moves `main` forward so subsequent changes accumulate under `0.1.17`.

Changes both version locations:
- `python/pyproject.toml`
- `python/model_hosting_container_standards/__init__.py`

No functional changes.